### PR TITLE
Update pandas dependency to support 2.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tested on
  
 ```bash
 # install time-series-anomaly-detector
-pip install time-series-anomaly-detector==0.3.5
+pip install time-series-anomaly-detector==0.3.6
 ```
  
 ## Installing from Source

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tested on
  
 ```bash
 # install time-series-anomaly-detector
-pip install time-series-anomaly-detector==0.3.6
+pip install time-series-anomaly-detector==0.3.5
 ```
  
 ## Installing from Source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "time-series-anomaly-detector"
-version = "0.3.6"
+version = "0.3.5"
 description = "Time Series Anomaly Detector"
 readme = "README.md"
 requires-python = ">=3.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "time-series-anomaly-detector"
-version = "0.3.5"
+version = "0.3.6"
 description = "Time Series Anomaly Detector"
 readme = "README.md"
 requires-python = ">=3.10.0"
@@ -32,7 +32,7 @@ classifiers = [
 
 dependencies = [
     "numpy<2, >=1.23.5",
-    "pandas<2, >=1.3.5",
+    "pandas<=2.2.3, >=1.3.5",
     "seasonal>=0.3.1",
     "scipy<1.13.0, >=1.9.3",
     "pytz>=2018.9",

--- a/tests/uvad_test.py
+++ b/tests/uvad_test.py
@@ -100,10 +100,18 @@ class TestFunctional(unittest.TestCase):
         working_dir = os.path.dirname(os.path.realpath(__file__))
         cases = os.listdir(os.path.join(working_dir, sub_dir))
         for i, case in enumerate(cases):
-            
+            if case.startswith("._"):
+                continue
             print(f"case {i} {case}")
-            with open(os.path.join(working_dir, sub_dir, case), "r") as f:
-                content = json.load(f)
+            file_path = os.path.join(working_dir, sub_dir, case)
+            with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+                raw = f.read()
+                if not raw.strip():
+                    self.fail(f"Empty JSON file: {file_path}")
+                try:
+                    content = json.loads(raw)   
+                except json.JSONDecodeError as e:
+                    self.fail(f"Invalid JSON in {file_path}: {e}")
             
             if content['type'] == 'entire':
                 ret = call_entire(content)


### PR DESCRIPTION
This PR updates the pandas requirement to `>=1.3.5, <=2.2.3` to ensure compatibility with newer environments while maintaining backward support.

While testing the build using `cibuildwheel`, I encountered unrelated test failures caused by macOS system metadata files and a malformed JSON file. These have been addressed by:
- Skipping hidden `._*` files in the test loader
- Handling encoding more robustly when reading test data

After these fixes, Linux wheels build successfully using cibuildwheel. This PR also triggers GitHub Actions to verify cross-platform compatibility on macOS and Windows.

Let me know if you'd prefer the test fixes split into a separate PR.